### PR TITLE
Check for no valid cluster # to consider

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Type: Package
 Title: GMM for semi-supervised case a-la Mclust
 Version: 1.4
 Date: 2016-02-05
-Author: Jordan Yoder, tested by Theodore D. Drivas
+Author: Jordan Yoder & Youngser Park. Tested by Theodore D. Drivas
 Maintainer: Jordan Yoder <jyoder6@jhu.edu>
 Description: Performs GMM for semi-supervised case a-la Mclust
 License: GPL (>= 2) + LICENSE

--- a/R/ssClust.R
+++ b/R/ssClust.R
@@ -22,7 +22,7 @@ function(X,
   }
   
   Grange = Grange[Grange >= numberOfClassesKnown]
-  
+  if(length(Grange) == 0)stop("No valid number of clusters to consider.  Expand Grange.")
 
   
   #Go through all the models and apply semi-supervised clustering


### PR DESCRIPTION
This addresses the case when user specifies less clusters than known through supervision.
Also, add Youngser to package author since he wrote a function used.